### PR TITLE
Legacy video room testing

### DIFF
--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -17,12 +17,12 @@ doctest = false
 [dependencies]
 tracing-subscriber.workspace = true
 
+[dependencies.jarust]
+path = "../jarust"
+features = ["audio-bridge-plugin", "echo-test-plugin", "video-room-plugin"]
+
 [dev-dependencies]
 rand.workspace = true
 rstest = "0.25.0"
 tokio = { workspace = true, features = ["time", "macros", "rt-multi-thread"] }
 tracing.workspace = true
-
-[dev-dependencies.jarust]
-path = "../jarust"
-features = ["audio-bridge-plugin", "echo-test-plugin", "video-room-plugin"]

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -19,6 +19,7 @@ tracing-subscriber.workspace = true
 
 [dev-dependencies]
 rand.workspace = true
+rstest = "0.25.0"
 tokio = { workspace = true, features = ["time", "macros", "rt-multi-thread"] }
 tracing.workspace = true
 

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -19,7 +19,12 @@ tracing-subscriber.workspace = true
 
 [dependencies.jarust]
 path = "../jarust"
-features = ["audio-bridge-plugin", "echo-test-plugin", "video-room-plugin"]
+features = [
+    "audio-bridge-plugin",
+    "echo-test-plugin",
+    "video-room-plugin",
+    "legacy-video-room-plugin",
+]
 
 [dev-dependencies]
 rand.workspace = true

--- a/e2e/src/lib.rs
+++ b/e2e/src/lib.rs
@@ -1,6 +1,7 @@
+use jarust::core::jaconfig::JanusAPI;
 use tracing_subscriber::EnvFilter;
 
-/// For debuggin e2e tests
+/// For debugging e2e tests
 pub fn init_tracing_subscriber() {
     let env_filter = EnvFilter::from_default_env()
         .add_directive("jarust_core=trace".parse().unwrap())
@@ -8,4 +9,41 @@ pub fn init_tracing_subscriber() {
         .add_directive("jarust_interface=trace".parse().unwrap())
         .add_directive("jarust_rt=trace".parse().unwrap());
     tracing_subscriber::fmt().with_env_filter(env_filter).init();
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub enum ServerUrl {
+    MultistreamWebsocket,
+    MultistreamRestful,
+    LegacyWebsocket,
+    LegacyRestful,
+}
+
+impl ServerUrl {
+    pub fn url(&self) -> &'static str {
+        match self {
+            ServerUrl::MultistreamWebsocket => "ws://localhost:8188/ws",
+            ServerUrl::MultistreamRestful => "http://localhost:8088",
+            ServerUrl::LegacyWebsocket => "ws://localhost:9188/ws",
+            ServerUrl::LegacyRestful => "http://localhost:9088",
+        }
+    }
+
+    pub fn api(&self) -> JanusAPI {
+        match self {
+            ServerUrl::MultistreamWebsocket | ServerUrl::LegacyWebsocket => JanusAPI::WebSocket,
+            ServerUrl::MultistreamRestful | ServerUrl::LegacyRestful => JanusAPI::Restful,
+        }
+    }
+
+    pub fn is_legacy(&self) -> bool {
+        matches!(self, ServerUrl::LegacyWebsocket | ServerUrl::LegacyRestful)
+    }
+
+    pub fn is_multistream(&self) -> bool {
+        matches!(
+            self,
+            ServerUrl::MultistreamWebsocket | ServerUrl::MultistreamRestful
+        )
+    }
 }

--- a/e2e/src/lib.rs
+++ b/e2e/src/lib.rs
@@ -29,7 +29,7 @@ impl TestingEnv {
 
     pub fn api(&self) -> JanusAPI {
         match self {
-            Self::Multistream(api) | Self::Legacy(api) => return *api,
+            Self::Multistream(api) | Self::Legacy(api) => *api,
         }
     }
 

--- a/e2e/src/lib.rs
+++ b/e2e/src/lib.rs
@@ -12,38 +12,32 @@ pub fn init_tracing_subscriber() {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
-pub enum ServerUrl {
-    MultistreamWebsocket,
-    MultistreamRestful,
-    LegacyWebsocket,
-    LegacyRestful,
+pub enum TestingEnv {
+    Multistream(JanusAPI),
+    Legacy(JanusAPI),
 }
 
-impl ServerUrl {
+impl TestingEnv {
     pub fn url(&self) -> &'static str {
         match self {
-            ServerUrl::MultistreamWebsocket => "ws://localhost:8188/ws",
-            ServerUrl::MultistreamRestful => "http://localhost:8088",
-            ServerUrl::LegacyWebsocket => "ws://localhost:9188/ws",
-            ServerUrl::LegacyRestful => "http://localhost:9088",
+            Self::Multistream(JanusAPI::WebSocket) => "ws://localhost:8188/ws",
+            Self::Multistream(JanusAPI::Restful) => "http://localhost:8088",
+            Self::Legacy(JanusAPI::WebSocket) => "ws://localhost:9188/ws",
+            Self::Legacy(JanusAPI::Restful) => "http://localhost:9088",
         }
     }
 
     pub fn api(&self) -> JanusAPI {
         match self {
-            ServerUrl::MultistreamWebsocket | ServerUrl::LegacyWebsocket => JanusAPI::WebSocket,
-            ServerUrl::MultistreamRestful | ServerUrl::LegacyRestful => JanusAPI::Restful,
+            Self::Multistream(api) | Self::Legacy(api) => return *api,
         }
     }
 
     pub fn is_legacy(&self) -> bool {
-        matches!(self, ServerUrl::LegacyWebsocket | ServerUrl::LegacyRestful)
+        matches!(self, Self::Legacy(_))
     }
 
     pub fn is_multistream(&self) -> bool {
-        matches!(
-            self,
-            ServerUrl::MultistreamWebsocket | ServerUrl::MultistreamRestful
-        )
+        matches!(self, Self::Multistream(_))
     }
 }

--- a/e2e/tests/audiobridge.rs
+++ b/e2e/tests/audiobridge.rs
@@ -897,6 +897,7 @@ async fn audiobridge_participants_e2e(#[case] testing_env: TestingEnv) {
         assert_eq!(participants.participants.contains(&bob), false);
     }
 
+    // kick_all is only available in janus multistream
     if testing_env.is_multistream() {
         'kick_all: {
             alice_handle

--- a/e2e/tests/core.rs
+++ b/e2e/tests/core.rs
@@ -1,8 +1,9 @@
 #![allow(unused_labels)]
 
-use e2e::ServerUrl;
+use e2e::TestingEnv;
 use jarust::core::connect;
 use jarust::core::jaconfig::JaConfig;
+use jarust::core::jaconfig::JanusAPI;
 use jarust::core::prelude::Attach;
 use jarust::interface::error::Error::JanusError;
 use jarust::interface::japrotocol::GenericEvent;
@@ -13,19 +14,19 @@ use rstest::*;
 use std::time::Duration;
 
 #[rstest]
-#[case::multistream_ws(ServerUrl::MultistreamWebsocket)]
-#[case::multistream_restful(ServerUrl::MultistreamRestful)]
-#[case::legacy_ws(ServerUrl::LegacyWebsocket)]
-#[case::legacy_restful(ServerUrl::LegacyRestful)]
+#[case::multistream_ws(TestingEnv::Multistream(JanusAPI::WebSocket))]
+#[case::multistream_restful(TestingEnv::Multistream(JanusAPI::Restful))]
+#[case::legacy_ws(TestingEnv::Legacy(JanusAPI::WebSocket))]
+#[case::legacy_restful(TestingEnv::Legacy(JanusAPI::Restful))]
 #[tokio::test]
-async fn core_test(#[case] server_url: ServerUrl) {
+async fn core_test(#[case] testing_env: TestingEnv) {
     let config = JaConfig {
-        url: server_url.url().to_string(),
+        url: testing_env.url().to_string(),
         apisecret: None,
         server_root: "janus".to_string(),
         capacity: 32,
     };
-    let mut connection = connect(config, server_url.api(), RandomTransactionGenerator)
+    let mut connection = connect(config, testing_env.api(), RandomTransactionGenerator)
         .await
         .unwrap();
 

--- a/e2e/tests/core.rs
+++ b/e2e/tests/core.rs
@@ -1,8 +1,8 @@
 #![allow(unused_labels)]
 
+use e2e::ServerUrl;
 use jarust::core::connect;
 use jarust::core::jaconfig::JaConfig;
-use jarust::core::jaconfig::JanusAPI;
 use jarust::core::prelude::Attach;
 use jarust::interface::error::Error::JanusError;
 use jarust::interface::japrotocol::GenericEvent;
@@ -13,19 +13,19 @@ use rstest::*;
 use std::time::Duration;
 
 #[rstest]
-#[case::multistream_ws("ws://localhost:8188/ws", JanusAPI::WebSocket)]
-#[case::multistream_restful("http://localhost:8088", JanusAPI::Restful)]
-#[case::legacy_ws("ws://localhost:9188/ws", JanusAPI::WebSocket)]
-#[case::legacy_restful("http://localhost:9088", JanusAPI::Restful)]
+#[case::multistream_ws(ServerUrl::MultistreamWebsocket)]
+#[case::multistream_restful(ServerUrl::MultistreamRestful)]
+#[case::legacy_ws(ServerUrl::LegacyWebsocket)]
+#[case::legacy_restful(ServerUrl::LegacyRestful)]
 #[tokio::test]
-async fn core_test(#[case] url: &str, #[case] api: JanusAPI) {
+async fn core_test(#[case] server_url: ServerUrl) {
     let config = JaConfig {
-        url: url.to_string(),
+        url: server_url.url().to_string(),
         apisecret: None,
         server_root: "janus".to_string(),
         capacity: 32,
     };
-    let mut connection = connect(config, api, RandomTransactionGenerator)
+    let mut connection = connect(config, server_url.api(), RandomTransactionGenerator)
         .await
         .unwrap();
 

--- a/e2e/tests/echotest.rs
+++ b/e2e/tests/echotest.rs
@@ -1,3 +1,4 @@
+use e2e::TestingEnv;
 use jarust::core::jaconfig::JaConfig;
 use jarust::core::jaconfig::JanusAPI;
 use jarust::interface::tgenerator::RandomTransactionGenerator;
@@ -5,69 +6,24 @@ use jarust::plugins::echo_test::events::EchoTestEvent;
 use jarust::plugins::echo_test::events::PluginEvent;
 use jarust::plugins::echo_test::jahandle_ext::EchoTest;
 use jarust::plugins::echo_test::params::EchoTestStartParams;
+use rstest::*;
 use std::time::Duration;
 
+#[rstest]
+#[case::multistream_ws(TestingEnv::Multistream(JanusAPI::WebSocket))]
+#[case::multistream_restful(TestingEnv::Multistream(JanusAPI::Restful))]
+#[case::legacy_ws(TestingEnv::Legacy(JanusAPI::WebSocket))]
+#[case::legacy_restful(TestingEnv::Legacy(JanusAPI::Restful))]
 #[tokio::test]
-async fn echotest_ws_e2e() {
+async fn echotest_e2e(#[case] testing_env: TestingEnv) {
     let config = JaConfig {
-        url: "ws://localhost:8188/ws".to_string(),
+        url: testing_env.url().to_string(),
         apisecret: None,
         server_root: "janus".to_string(),
         capacity: 32,
     };
     let mut connection =
-        jarust::core::connect(config, JanusAPI::WebSocket, RandomTransactionGenerator)
-            .await
-            .expect("Failed to connect to server");
-    let timeout = Duration::from_secs(10);
-    let session = connection
-        .create_session(10, Duration::from_secs(10))
-        .await
-        .expect("Failed to create session");
-    let (handle, mut event_receiver) = session
-        .attach_echo_test(timeout)
-        .await
-        .expect("Failed to attach plugin");
-
-    handle
-        .start(EchoTestStartParams {
-            audio: Some(true),
-            ..Default::default()
-        })
-        .await
-        .expect("Failed to send start message");
-    assert_eq!(
-        event_receiver.recv().await,
-        Some(PluginEvent::EchoTestEvent(EchoTestEvent::Result {
-            echotest: "event".to_string(),
-            result: "ok".to_string()
-        }))
-    );
-
-    // Empty body should return an error
-    handle
-        .start(Default::default())
-        .await
-        .expect("Failed to send start message");
-    assert!(matches!(
-        event_receiver.recv().await,
-        Some(PluginEvent::EchoTestEvent(EchoTestEvent::Error {
-            error_code: _,
-            error: _
-        }))
-    ));
-}
-
-#[tokio::test]
-async fn echotest_rest_e2e() {
-    let config = JaConfig {
-        url: "http://localhost:8088".to_string(),
-        apisecret: None,
-        server_root: "janus".to_string(),
-        capacity: 32,
-    };
-    let mut connection =
-        jarust::core::connect(config, JanusAPI::Restful, RandomTransactionGenerator)
+        jarust::core::connect(config, testing_env.api(), RandomTransactionGenerator)
             .await
             .expect("Failed to connect to server");
     let timeout = Duration::from_secs(10);

--- a/e2e/tests/legacy_videoroom.rs
+++ b/e2e/tests/legacy_videoroom.rs
@@ -18,7 +18,7 @@ use tokio::sync::mpsc::UnboundedReceiver;
 #[case::legacy_ws(TestingEnv::Legacy(JanusAPI::WebSocket))]
 #[case::legacy_restful(TestingEnv::Legacy(JanusAPI::Restful))]
 #[tokio::test]
-async fn videoroom_room_crud_e2e(#[case] testing_env: TestingEnv) {
+async fn legacy_videoroom_room_crud_e2e(#[case] testing_env: TestingEnv) {
     let default_timeout = Duration::from_secs(4);
     let handle = make_legacy_videoroom_attachment(testing_env).await.0;
     let room_id = JanusId::Uint(rand::random::<u64>().into());

--- a/e2e/tests/legacy_videoroom.rs
+++ b/e2e/tests/legacy_videoroom.rs
@@ -1,0 +1,88 @@
+#![allow(unused_labels)]
+
+use e2e::TestingEnv;
+use jarust::core::jaconfig::JaConfig;
+use jarust::core::jaconfig::JanusAPI;
+use jarust::interface::tgenerator::RandomTransactionGenerator;
+use jarust::plugins::legacy_video_room::events::PluginEvent;
+use jarust::plugins::legacy_video_room::handle::LegacyVideoRoomHandle;
+use jarust::plugins::legacy_video_room::jahandle_ext::LegacyVideoRoom;
+use jarust::plugins::legacy_video_room::params::LegacyVideoRoomCreateParams;
+use jarust::plugins::legacy_video_room::params::LegacyVideoRoomExistsParams;
+use jarust::plugins::JanusId;
+use rstest::*;
+use std::time::Duration;
+use tokio::sync::mpsc::UnboundedReceiver;
+
+#[rstest]
+#[case::legacy_ws(TestingEnv::Legacy(JanusAPI::WebSocket))]
+#[case::legacy_restful(TestingEnv::Legacy(JanusAPI::Restful))]
+#[tokio::test]
+async fn videoroom_room_crud_e2e(#[case] testing_env: TestingEnv) {
+    let default_timeout = Duration::from_secs(4);
+    let handle = make_legacy_videoroom_attachment(testing_env).await.0;
+    let room_id = JanusId::Uint(rand::random::<u64>().into());
+
+    'before_creation: {
+        let exists = handle
+            .exists(
+                LegacyVideoRoomExistsParams {
+                    room: room_id.clone(),
+                },
+                default_timeout,
+            )
+            .await
+            .expect("Failed to check if room exists; before_creation");
+        assert!(!exists, "Room should not exist before creation");
+    }
+
+    'creation: {
+        handle
+            .create_room(
+                LegacyVideoRoomCreateParams {
+                    room: Some(room_id.clone()),
+                    ..Default::default()
+                },
+                default_timeout,
+            )
+            .await
+            .expect("Failed to create room; creation");
+
+        let exists = handle
+            .exists(
+                LegacyVideoRoomExistsParams {
+                    room: room_id.clone(),
+                },
+                default_timeout,
+            )
+            .await
+            .expect("Failed to check if room exists; creation");
+        assert!(exists, "Room should exist after creation");
+    }
+}
+
+async fn make_legacy_videoroom_attachment(
+    testing_env: TestingEnv,
+) -> (LegacyVideoRoomHandle, UnboundedReceiver<PluginEvent>) {
+    let config = JaConfig {
+        url: testing_env.url().to_string(),
+        apisecret: None,
+        server_root: "janus".to_string(),
+        capacity: 32,
+    };
+    let mut connection =
+        jarust::core::connect(config, testing_env.api(), RandomTransactionGenerator)
+            .await
+            .expect("Failed to connect to server");
+    let timeout = Duration::from_secs(10);
+    let session = connection
+        .create_session(10, Duration::from_secs(10))
+        .await
+        .expect("Failed to create session");
+    let (handle, event_receiver) = session
+        .attach_legacy_video_room(timeout)
+        .await
+        .expect("Failed to attach plugin");
+
+    (handle, event_receiver)
+}

--- a/jarust_core/src/jaconfig.rs
+++ b/jarust_core/src/jaconfig.rs
@@ -11,7 +11,7 @@ pub struct JaConfig {
     pub capacity: usize,
 }
 
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub enum JanusAPI {
     WebSocket,
     Restful,


### PR DESCRIPTION
- Created legacy video room e2e test that currently only contains tests for `exist` and `create_room`
- Added `rstest` to parameterize testing so we could test multistream and legacy janus with websocket and restful transports.