### PR TITLE
Closure support for transaction generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ serde_json = "1.0.140"
 thiserror = "1.0.69"
 tokio = "1.44.2"
 tracing = "0.1.41"
+uuid = "1.11.0"
 
 # Dev deps
 anyhow = "1.0.98"

--- a/jarust/Cargo.toml
+++ b/jarust/Cargo.toml
@@ -57,6 +57,7 @@ serde.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing-subscriber.workspace = true
 tracing.workspace = true
+uuid = { workspace = true, features = ["fast-rng", "v4"] }
 
 [dev-dependencies.jarust_plugins]
 workspace = true

--- a/jarust/examples/raw_echotest.rs
+++ b/jarust/examples/raw_echotest.rs
@@ -2,7 +2,6 @@ use jarust::core::connect;
 use jarust::core::jaconfig::JaConfig;
 use jarust::core::jaconfig::JanusAPI;
 use jarust::core::prelude::Attach;
-use jarust::interface::tgenerator::RandomTransactionGenerator;
 use serde_json::json;
 use std::time::Duration;
 use tracing_subscriber::EnvFilter;
@@ -18,7 +17,8 @@ async fn main() -> anyhow::Result<()> {
         server_root: "janus".to_string(),
         capacity: 32,
     };
-    let mut connection = connect(config, JanusAPI::WebSocket, RandomTransactionGenerator).await?;
+    let tgenerator = || uuid::Uuid::new_v4().to_string();
+    let mut connection = connect(config, JanusAPI::WebSocket, tgenerator).await?;
     let timeout = Duration::from_secs(10);
     let session = connection
         .create_session(10, Duration::from_secs(10))

--- a/jarust_interface/Cargo.toml
+++ b/jarust_interface/Cargo.toml
@@ -26,7 +26,7 @@ serde.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["sync", "time", "rt"] }
 tracing.workspace = true
-uuid = { version = "1.11.0", features = ["fast-rng", "v4"] }
+uuid = { workspace = true, features = ["fast-rng", "v4"] }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 rustls = { version = "0.23.20", optional = true }

--- a/jarust_interface/src/tgenerator.rs
+++ b/jarust_interface/src/tgenerator.rs
@@ -4,8 +4,23 @@ use std::ops::Deref;
 /// GenerateTransaction can be provided to an interface for generating messages transactions.
 ///
 /// The more they're unique the better, especially when choosing with WebSockets interface as demultiplexing heavily relies on transaction ids.
-pub trait GenerateTransaction: Send + Sync + Debug + 'static {
+pub trait GenerateTransaction: Send + Sync + 'static {
     fn generate_transaction(&self) -> String;
+}
+
+impl<F> GenerateTransaction for F
+where
+    F: Fn() -> String + Send + Sync + 'static,
+{
+    fn generate_transaction(&self) -> String {
+        self()
+    }
+}
+
+impl Debug for dyn GenerateTransaction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("GenerateTransaction").finish()
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Transaction generation now supports passing closure

### Example:

Creating uuid v4 string per transaction

```rust
let tgenerator = || uuid::Uuid::new_v4().to_string();
let mut connection = connect(config, JanusAPI::WebSocket, tgenerator).await?;
```

The trait implementation is still available:

```rust
#[derive(Debug)]
pub struct UuidTransactionGenerator;

impl GenerateTransaction for UuidTransactionGenerator {
    fn generate_transaction(&self) -> String {
        uuid::Uuid::new_v4().to_string()
    }
}

let mut connection = connect(config, JanusAPI::WebSocket, UuidTransactionGenerator).await?;
```
