### PR TITLE
fix: fix plugin config paths in top level compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,9 @@ services:
       - "10000-10200:10000-10200/udp"
     volumes:
       - "./server_config/janus.jcfg:/etc/janus/janus.jcfg"
-      - "./server_config/janus.plugin.audiobridge.jcfg:/etc/janus/janus.plugin.audiobridge.jcfg"
-      - "./server_config/janus.plugin.videoroom.jcfg:/etc/janus/janus.plugin.videoroom.jcfg"
+      - "./server_config/janus.plugin.audiobridge.jcfg:/opt/janus/etc/janus/janus.plugin.audiobridge.jcfg"
+      - "./server_config/janus.plugin.streaming.jcfg:/opt/janus/etc/janus/janus.plugin.streaming.jcfg"
+      - "./server_config/janus.plugin.videoroom.jcfg:/opt/janus/etc/janus/janus.plugin.videoroom.jcfg"
     restart: always
 
   janus-gateway-legacy:
@@ -31,6 +32,7 @@ services:
       - "11000-11200:10000-10200/udp"
     volumes:
       - "./server_config/janus.jcfg:/etc/janus/janus.jcfg"
-      - "./server_config/janus.plugin.audiobridge.jcfg:/etc/janus/janus.plugin.audiobridge.jcfg"
-      - "./server_config/janus.plugin.videoroom.jcfg:/etc/janus/janus.plugin.videoroom.jcfg"
+      - "./server_config/janus.plugin.audiobridge.jcfg:/opt/janus/etc/janus/janus.plugin.audiobridge.jcfg"
+      - "./server_config/janus.plugin.streaming.jcfg:/opt/janus/etc/janus/janus.plugin.streaming.jcfg"
+      - "./server_config/janus.plugin.videoroom.jcfg:/opt/janus/etc/janus/janus.plugin.videoroom.jcfg"
     restart: always


### PR DESCRIPTION
Given the build prefix of janus (/opt/janus) plugins configuration are expected to be in /opt/janus/etc/janus, not /etc/janus. Note that the image explicitly use the configuration /etc/janus/janus.jcfg so no need to change the mount path for it.