### PR TITLE
chore(release): bump version to 1.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.7.2"
+version = "1.8.0"
 authors = ["Hamza Jadid"]
 description = "A janus client SDK in Rust"
 readme = "README.md"
@@ -22,10 +22,10 @@ repository = "https://github.com/Proximie/jarust"
 
 [workspace.dependencies]
 # Workspace crates
-jarust_core = { version = "1.7.2", path = "jarust_core" }
-jarust_interface = { version = "1.7.2", path = "jarust_interface" }
-jarust_plugins = { version = "1.7.2", path = "jarust_plugins" }
-jarust_rt = { version = "1.7.2", path = "jarust_rt" }
+jarust_core = { version = "1.8.0", path = "jarust_core" }
+jarust_interface = { version = "1.8.0", path = "jarust_interface" }
+jarust_plugins = { version = "1.8.0", path = "jarust_plugins" }
+jarust_rt = { version = "1.8.0", path = "jarust_rt" }
 
 # 3rd Party
 async-trait = "0.1.87"
@@ -35,9 +35,9 @@ rand = "0.8.5"
 serde = { version = "1.0.218", features = ["derive"] }
 serde_json = "1.0.140"
 thiserror = "1.0.69"
-tokio = "1.44.2"
+tokio = "1.46.1"
 tracing = "0.1.41"
-uuid = "1.11.0"
+uuid = "1.17.0"
 
 # Dev deps
 anyhow = "1.0.98"


### PR DESCRIPTION
Change log: https://github.com/Proximie/jarust/releases/tag/1.8.0